### PR TITLE
Debug appscript permission and ui errors

### DIFF
--- a/deploy/CollectConfig.gs
+++ b/deploy/CollectConfig.gs
@@ -41,10 +41,11 @@ function getLog() {
 // ГЛАВНАЯ ФУНКЦИЯ: Открыть UI
 // ============================================================================
 function openCollectConfigUI() {
-  try {
-    // Ensure we trigger OAuth consent for user email if needed (required for templates/presets)
-    ensureEmailAuth();
+  // Ensure we trigger OAuth consent for user email if needed (required for templates/presets)
+  // This call MUST be outside of try/catch so Apps Script shows the consent prompt.
+  ensureEmailAuth();
 
+  try {
     const html = HtmlService.createHtmlOutputFromFile('CollectConfigUi')
       .setWidth(700)
       .setTitle('🎯 AI Конструктор v3.0');
@@ -646,6 +647,9 @@ function hasConfigForCurrentCell() {
 // ПРОСТОЙ UI ДЛЯ УПРАВЛЕНИЯ ШАБЛОНАМИ
 // ============================================================================
 function openTemplatesUI() {
+  // Trigger OAuth consent if needed before accessing user email
+  ensureEmailAuth();
+
   try {
     const user = Session.getActiveUser().getEmail() || 'anonymous';
     const templates = getAllTemplates(user);
@@ -676,7 +680,7 @@ function openTemplatesUI() {
       SpreadsheetApp.getUi().ButtonSet.OK
     );
   } catch (error) {
-    SpreadsheetApp.getUi().alert('Ошибка', 'Не удалось загрузить шаблоны: ' + error.message);
+    SpreadsheetApp.getUi().alert('Ошибка', 'Не удалось загрузить шаблоны: ' + error.message, SpreadsheetApp.getUi().ButtonSet.OK);
   }
 }
 


### PR DESCRIPTION
Trigger OAuth consent for `userinfo.email` and fix `Ui.alert` signature error.

Moving `ensureEmailAuth()` outside `try/catch` blocks ensures the Apps Script OAuth consent dialog is properly displayed, resolving the permission error for `Session.getActiveUser`. The `Ui.alert` fix addresses a runtime error caused by an incorrect number of arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad3f34bd-7da0-448c-bbde-92fca8628c34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad3f34bd-7da0-448c-bbde-92fca8628c34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

