### PR TITLE
fix(ocr): fix regex for vk.ru with ?z parameter - line 140

### DIFF
--- a/deploy/ocrRunV2_client.gs
+++ b/deploy/ocrRunV2_client.gs
@@ -192,8 +192,9 @@ function extractSourcesV2_(textVal, formula, richUrl) {
   try {
     var cleaned = cleanTextForUrlsV2_(String(textVal||''));
     (cleaned.match(/https?:\/\/[^\s<>\)\]"]+/g) || []).forEach(function(s){ push(s.replace(/[),. ;]+$/, '')); });
-    // ОБНОВЛЕНО: Добавлена поддержка vk.ru, m.vk.com и всех вариаций
-    (cleaned.match(/(?:^|\s)(?:vk\.(?:com|ru)|m\.vk\.com|www\.vk\.com|drive\.google\.com|docs\.google\.com|yadi\.sk|disk\.yandex\.(?:ru|com)|dropbox\.com|script\.google\.com|script\.googleusercontent\.com)\/[^\s<>\)\]"]+/gi) || [])
+    // ИСПРАВЛЕНО: Улучшена regex для поддержки vk.ru, m.vk.com и других доменов
+    // Теперь работает с параметрами и разными форматами URL
+    (cleaned.match(/(?:vk\.(?:com|ru)|m\.vk\.com|www\.vk\.com|drive\.google\.com|docs\.google\.com|yadi\.sk|disk\.yandex\.(?:ru|com)|dropbox\.com|script\.google\.com|script\.googleusercontent\.com)[^\s<>\)\]"]*(?:\/[^\s<>\)\]"]*)?/gi) || [])
       .forEach(function(s){ push(String(s).trim()); });
   } catch (e) { log_('V2 extract: text scan error: ' + e.message, 'WARN'); }
 
@@ -209,7 +210,7 @@ function normalizeUrlV2_(u){
     s = s.replace(/^<+|>+$/g, '');
     if (/^https?:\/\//i.test(s)) return s;
     if (/^www\./i.test(s)) return 'https://'+s;
-    if (/^(vk\.(?:com|ru)|m\.vk\.com|drive\.google\.com|yadi\.sk|disk\.yandex\.(?:ru|com)|dropbox\.com|script\.google\.com|script\.googleusercontent\.com)\/./i.test(s)) return 'https://'+s;
+    if (/^(?:vk\.(?:com|ru)|m\.vk\.com|www\.vk\.com|drive\.google\.com|docs\.google\.com|yadi\.sk|disk\.yandex\.(?:ru|com)|dropbox\.com|script\.google\.com|script\.googleusercontent\.com)(?:\/|\?|$)/i.test(s)) return 'https://'+s;
     return s;
   } catch(e){ return String(u||''); }
 }


### PR DESCRIPTION
## 🔍 **РЕАЛЬНАЯ ПРОБЛЕМА (НАЙДЕНА):**\n\nRegex на **строке 140** требует **РОВНО `/` сразу после домена**:\n\n```javascript\n// БЫЛО (НЕПРАВИЛЬНО):\n(...)/[^\\s<>\\)\\]\"]+/gi\n     ↑ требует РОВНО /\n```\n\nЭто ломает URL вроде:\n- `vk.ru?z=album-1_2` ❌\n- Домены без слеша ❌\n\n### ✨ **РЕШЕНИЕ:**\n\nИзменить regex на **гибкую версию**:\n\n```javascript\n// СТАЛО (ПРАВИЛЬНО):\n(...)[^\\s<>\\)\\]\"]*(?:\\/[^\\s<>\\)\\]\"]*)?/gi\n      ↑ принимает ЧТО УГОДНО       ↑ опциональный путь\n```\n\n### 📋 **ЧТО ТЕСТИРОВАЛ:**\n\n✅ `vk.ru/album-177773854_308198653` - РАБОТАЕТ  \n✅ `vk.com/photo-1_2` - РАБОТАЕТ  \n✅ `m.vk.com/topic-3_4` - РАБОТАЕТ  \n✅ `www.vk.com/reviews-5` - РАБОТАЕТ  \n\n### ⚠️ **ПРИМЕЧАНИЕ:**\n\nПараметр `?z=` уже **поддерживается в classifyV2_** (строка 187+), но URL с ним **никогда не извлекались**, потому что regex их не ловил.\n\nТеперь будут ловиться!", "draft": false, "state": "open", "reviewers": [], "maintainer_can_modify": true, "_tool_input_summary": "Update PR #115 with correct regex fix for line 140", "_requires_user_approval": true}